### PR TITLE
simulate and handle session timeouts

### DIFF
--- a/e2e/session-timeout.spec.ts
+++ b/e2e/session-timeout.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from '../test-data/fixtures';
+
+const SESSION_WARNING_TIME = 18 * 60 * 1000; // 18 minutes
+const SESSION_EXPIRY_TIME = 20 * 60 * 1000; // 20 minutes
+const BUFFER_TIME = 2 * 60 * 1000; // 2 minute buffer
+
+const MODAL_HEADER = 'Session about to expire';
+const MODAL_BODY = 'Your session will expire in';
+const BTN_STAY_LOGGED_IN = 'Stay logged in';
+const BTN_LOG_OUT = 'Log out';
+
+test.describe('Session Management', () => {
+    test.setTimeout(SESSION_EXPIRY_TIME + 5 * 60 * 1000);
+
+    test('session timeout warning appears before expiry', async ({
+        page,
+        login,
+    }) => {
+        await login();
+
+        const sidebar = page
+            .locator('li.leeds_list_item')
+            .filter({ hasText: 'My Accounts' });
+        await expect(sidebar).toBeVisible();
+
+        const modalHeader = page.getByText(MODAL_HEADER);
+        await expect(modalHeader).toBeVisible({
+            timeout: SESSION_WARNING_TIME + BUFFER_TIME,
+        });
+
+        await expect(page.getByText(MODAL_BODY)).toBeVisible();
+        await expect(page.getByText(BTN_STAY_LOGGED_IN)).toBeVisible();
+        await expect(page.getByText(BTN_LOG_OUT)).toBeVisible();
+    });
+
+    test('clicking "Stay logged in" extends session', async ({
+        page,
+        login,
+    }) => {
+        await login();
+
+        const sidebar = page
+            .locator('li.leeds_list_item')
+            .filter({ hasText: 'My Accounts' });
+        await expect(sidebar).toBeVisible();
+
+        const modalHeader = page.getByText(MODAL_HEADER);
+        await expect(modalHeader).toBeVisible({
+            timeout: SESSION_WARNING_TIME + BUFFER_TIME,
+        });
+
+        const stayLoggedInBtn = page.getByText(BTN_STAY_LOGGED_IN);
+        await stayLoggedInBtn.click();
+
+        await expect(modalHeader).not.toBeVisible({ timeout: 10_000 });
+
+        await expect(sidebar).toBeVisible();
+    });
+
+    test('clicking "Log out" logs user out', async ({ page, login }) => {
+        await login();
+
+        const sidebar = page
+            .locator('li.leeds_list_item')
+            .filter({ hasText: 'My Accounts' });
+        await expect(sidebar).toBeVisible();
+
+        const modalHeader = page.getByText(MODAL_HEADER);
+        await expect(modalHeader).toBeVisible({
+            timeout: SESSION_WARNING_TIME + BUFFER_TIME,
+        });
+
+        const logOutBtn = page.getByText(BTN_LOG_OUT);
+        await logOutBtn.click();
+
+        const loginForm = page.locator('#step01');
+        await expect(loginForm).toBeVisible({ timeout: 60_000 });
+    });
+
+    test('expired session redirects to login automatically', async ({
+        page,
+        login,
+    }) => {
+        await login();
+
+        const sidebar = page
+            .locator('li.leeds_list_item')
+            .filter({ hasText: 'My Accounts' });
+        await expect(sidebar).toBeVisible();
+
+        // wait for full session expiry (~20 minutes)
+        // don't interact with the warning modal - let it expire
+        const loginForm = page.locator('#step01');
+        await expect(loginForm).toBeVisible({
+            timeout: SESSION_EXPIRY_TIME + BUFFER_TIME,
+        });
+    });
+
+    test('page refresh with valid session stays logged in', async ({
+        page,
+        login,
+    }) => {
+        await login();
+
+        const sidebar = page
+            .locator('li.leeds_list_item')
+            .filter({ hasText: 'My Accounts' });
+        await expect(sidebar).toBeVisible();
+
+        await page.waitForTimeout(5 * 60 * 1000);
+
+        await page.reload();
+
+        await expect(sidebar).toBeVisible({ timeout: 120_000 });
+    });
+});

--- a/e2e/uat-access-validation.spec.ts
+++ b/e2e/uat-access-validation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../test-data/fixtures';
+import { expect, test } from '../test-data/fixtures';
 
 test.describe('Authentication', () => {
     test('valid login reaches dashboard', async ({ page, login }) => {

--- a/test-data/fixtures.ts
+++ b/test-data/fixtures.ts
@@ -1,13 +1,20 @@
 import { test as base, expect } from '@playwright/test';
-import { getDefaultUser, getUser, type TestUser } from './users';
+import {
+    getDefaultUser,
+    getUser,
+    getUserByWorkerIndex,
+    type TestUser,
+} from './users';
 
 type TestFixtures = {
     testUser: TestUser;
     login: () => Promise<void>;
+    reAuthenticate: () => Promise<void>;
 };
 
 type TestOptions = {
     userId: string;
+    useWorkerUser: boolean;
 };
 
 async function humanDelay(
@@ -33,9 +40,17 @@ async function humanType(
 
 export const test = base.extend<TestFixtures & TestOptions>({
     userId: ['', { option: true }],
+    useWorkerUser: [false, { option: true }],
 
-    testUser: async ({ userId }, use) => {
-        const user = userId ? getUser(userId) : getDefaultUser();
+    testUser: async ({ userId, useWorkerUser }, use, workerInfo) => {
+        let user: TestUser;
+        if (useWorkerUser) {
+            user = getUserByWorkerIndex(workerInfo.workerIndex);
+        } else if (userId) {
+            user = getUser(userId);
+        } else {
+            user = getDefaultUser();
+        }
         await use(user);
     },
 
@@ -109,6 +124,43 @@ export const test = base.extend<TestFixtures & TestOptions>({
                 .locator('li.leeds_list_item')
                 .filter({ hasText: 'My Accounts' });
             await expect(dashboardIndicator).toBeVisible({ timeout: 120_000 });
+        });
+    },
+
+    reAuthenticate: async ({ page, login }, use) => {
+        await use(async () => {
+            const loginForm = page.locator('#step01');
+            const isOnLoginPage = await loginForm
+                .isVisible({ timeout: 5_000 })
+                .catch(() => false);
+
+            if (isOnLoginPage) {
+                await login();
+                return;
+            }
+
+            const sessionModal = page.getByText('Session about to expire');
+            const hasSessionWarning = await sessionModal
+                .isVisible({ timeout: 1_000 })
+                .catch(() => false);
+
+            if (hasSessionWarning) {
+                const stayLoggedIn = page.getByText('Stay logged in');
+                await stayLoggedIn.click();
+                await expect(sessionModal).not.toBeVisible({ timeout: 10_000 });
+                return;
+            }
+
+            const sidebar = page
+                .locator('li.leeds_list_item')
+                .filter({ hasText: 'My Accounts' });
+            const isLoggedIn = await sidebar
+                .isVisible({ timeout: 5_000 })
+                .catch(() => false);
+
+            if (!isLoggedIn) {
+                await login();
+            }
         });
     },
 });

--- a/test-data/fixtures.ts
+++ b/test-data/fixtures.ts
@@ -43,7 +43,7 @@ export const test = base.extend<TestFixtures & TestOptions>({
         await use(async () => {
             const baseUrl = process.env.BASE_URL;
             if (!baseUrl) {
-              throw new Error('BASE_URL required');
+                throw new Error('BASE_URL required');
             }
 
             await page.goto(`${baseUrl}/#/administrationGeneral/login`);

--- a/test-data/users.example.json
+++ b/test-data/users.example.json
@@ -1,7 +1,7 @@
 {
-    "userNickname": {
-        "name": "Kory James",
-        "username": "username",
+    "user1": {
+        "name": "Test User 1",
+        "username": "testuser1",
         "password": "your-password-here",
         "smsCode": "222222",
         "accounts": [
@@ -13,22 +13,44 @@
             }
         ]
     },
-    "anotherUser": {
-        "name": "Another User",
-        "username": "anotheruser",
+    "user2": {
+        "name": "Test User 2",
+        "username": "testuser2",
         "password": "your-password-here",
-        "smsCode": "123456",
+        "smsCode": "222222",
         "accounts": [
             {
                 "name": "Savings Account",
                 "type": "savings",
-                "number": "1234567890",
+                "number": "1234567891",
                 "currency": "TTD"
-            },
+            }
+        ]
+    },
+    "user3": {
+        "name": "Test User 3",
+        "username": "testuser3",
+        "password": "your-password-here",
+        "smsCode": "222222",
+        "accounts": [
             {
                 "name": "Credit Card",
                 "type": "credit",
                 "number": "5140-XXXX-XXXX-1234",
+                "currency": "TTD"
+            }
+        ]
+    },
+    "user4": {
+        "name": "Test User 4",
+        "username": "testuser4",
+        "password": "your-password-here",
+        "smsCode": "222222",
+        "accounts": [
+            {
+                "name": "Chequing Account",
+                "type": "chequing",
+                "number": "1234567892",
                 "currency": "TTD"
             }
         ]

--- a/test-data/users.ts
+++ b/test-data/users.ts
@@ -91,3 +91,15 @@ export function getUser(id: string): TestUser {
 export function getDefaultUser(): TestUser {
     return testUsers[0];
 }
+
+/**
+ *
+ * get a user by worker index for parallel test execution.
+ * cycles through available users if worker index exceeds user count.
+ *
+ */
+export function getUserByWorkerIndex(workerIndex: number): TestUser {
+    const userIndex = workerIndex % testUsers.length;
+    
+    return testUsers[userIndex];
+}


### PR DESCRIPTION
## Description
```
  5 Tests Created:
  ┌──────────────────────────────────────────────────┬───────────┬───────────────────────────────────────────────┐
  │                       Test                       │ Wait Time │               What it Verifies                │
  ├──────────────────────────────────────────────────┼───────────┼───────────────────────────────────────────────┤
  │ session timeout warning appears before expiry    │ ~18 min   │ Modal appears with header, body, both buttons │
  ├──────────────────────────────────────────────────┼───────────┼───────────────────────────────────────────────┤
  │ clicking "Stay logged in" extends session        │ ~18 min   │ Modal dismissed, user stays on dashboard      │
  ├──────────────────────────────────────────────────┼───────────┼───────────────────────────────────────────────┤
  │ clicking "Log out" logs user out                 │ ~18 min   │ Redirects to login page                       │
  ├──────────────────────────────────────────────────┼───────────┼───────────────────────────────────────────────┤
  │ expired session redirects to login automatically │ ~20 min   │ Auto-logout when modal ignored                │
  ├──────────────────────────────────────────────────┼───────────┼───────────────────────────────────────────────┤
  │ page refresh with valid session stays logged in  │ 5 min     │ Refresh doesn't break session                 │
  └──────────────────────────────────────────────────┴───────────┴───────────────────────────────────────────────┘
```
## Related Issue

<!-- Link the issue this PR addresses -->
Fixes #51 

## Type of Change

- [x] New test
- [ ] Bug fix
- [ ] Test update / refactor
- [ ] Documentation
- [ ] Configuration change

## Changes Made
- created tests for inactivity timeout 

## Test Results

**Tests passing**: 5/5

## Checklist

- [x] Branch follows naming convention (`feature/`, `bugfix/`, `hotfix/`)
- [x] Commits follow conventional format (`feat:`, `fix:`, `test:`, `docs:`)
- [x] Code is formatted (`npm run format`)
- [x] Linter passes (`npm run lint`)
- [x] All tests pass (`npm test`)
- [x] New selectors are documented in CONTRIBUTING.md (if applicable)
- [ ] Screenshots captured for new tests

## Notes for Reviewers
- TODO: re-authentication 
- need to parallelize and optimize this (takes 1.4 hours-ish to run these tests)